### PR TITLE
Don't use display_identifier as OpenID identifier.

### DIFF
--- a/lib/open_id_authentication.rb
+++ b/lib/open_id_authentication.rb
@@ -107,7 +107,7 @@ module OpenIdAuthentication
 
     def complete_open_id_authentication
       response   = request.env[Rack::OpenID::RESPONSE]
-      identifier = response.display_identifier
+      identifier = response.identity_url
 
       case response.status
       when OpenID::Consumer::SUCCESS


### PR DESCRIPTION
display_identifier isn't OpenID identifier.
If a user deleted his OP account, display_identifier could be assigned to another user who got the same username at least at Yahoo!

Simply, use "identity_url".
